### PR TITLE
Updated support for figma css variables

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -4,7 +4,7 @@
 // You can access browser APIs in the <script> tag inside "ui.html" which has a
 // full browser environment (see documentation).
 // This shows the HTML page in "ui.html".
-figma.showUI(__html__, { width: 350, height: 200 });
+figma.showUI(__html__, { width: 350, height: 200, themeColors: true });
 // Calls to "parent.postMessage" from within the HTML page will trigger this
 // callback. The callback will be passed the "pluginMessage" property of the
 // posted message.


### PR DESCRIPTION
For access to their CSS variables, Figma now requires the `themeColors` option when calling `figma.showUI`.

This fixes the issue where it looks like some styles aren't being applied.